### PR TITLE
Add support for bigints and symbols

### DIFF
--- a/Jakefile.js
+++ b/Jakefile.js
@@ -77,6 +77,13 @@
 
 	function sharedLintOptions() {
 		return {
+			esversion:6,
+			globals: {
+				BigInt:false
+			},
+			unstable: {
+				bigint:true
+			},
 			bitwise:true,
 			curly:false,
 			eqeqeq:true,

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "expect.js": "^0.3.1",
     "http-server": "^0.11.1",
     "jake": "^8.0.15",
-    "jshint": "^2.1.2",
+    "jshint": "^2.11.1",
     "karma": "^2.0.0",
     "karma-expect": "^1.1.0",
     "karma-mocha": "^1.3.0",

--- a/src/_object_graph_test.js
+++ b/src/_object_graph_test.js
@@ -109,7 +109,8 @@
 					f: Number.prototype,
 					g: Date.prototype,
 					h: RegExp.prototype,
-					i: Error.prototype
+					i: Error.prototype,
+					j: BigInt.prototype
 				};
 				expect(nodes(object)).to.eql([object]);
 			});

--- a/src/_object_node_test.js
+++ b/src/_object_node_test.js
@@ -138,6 +138,13 @@
 				expect(conversionOf(1)).to.equal("1");
 
 				expect(conversionOf("string")).to.equal('"string"');
+
+				expect(conversionOf(0n)).to.equal("0n");
+				expect(conversionOf(1n)).to.equal("1n");
+
+				expect(conversionOf(Symbol())).to.equal("Symbol()");
+				expect(conversionOf(Symbol('description'))).to.equal("Symbol(description)");
+				expect(conversionOf(Symbol.iterator)).to.equal("Symbol(Symbol.iterator)");
 			});
 
 			it("converts functions", function() {

--- a/src/object_graph.js
+++ b/src/object_graph.js
@@ -105,7 +105,7 @@ window.jdls = window.jdls || {};
 			value === Date.prototype ||
 			value === RegExp.prototype ||
 			value === Error.prototype ||
-			typeof BigInt !== 'undefined' && value === BigInt.prototype; // jshint ignore:line
+			typeof BigInt !== 'undefined' && value === BigInt.prototype;
 	}
 
 	function isOrdinaryFunction(node, propertyName) {

--- a/src/object_graph.js
+++ b/src/object_graph.js
@@ -104,7 +104,8 @@ window.jdls = window.jdls || {};
 			value === Number.prototype ||
 			value === Date.prototype ||
 			value === RegExp.prototype ||
-			value === Error.prototype;
+			value === Error.prototype ||
+			typeof BigInt !== 'undefined' && value === BigInt.prototype; // jshint ignore:line
 	}
 
 	function isOrdinaryFunction(node, propertyName) {

--- a/src/object_node.js
+++ b/src/object_node.js
@@ -98,9 +98,11 @@ window.jdls = window.jdls || {};
 
 		switch (typeof value) {
 			case "string": return '"' + value + '"';
+			case "bigint": return value + "n";
 			case "function":
 			case "object":
 				return objectName("{" + objectType(value) + "}", value);
+			case "symbol": return String(value);
 			default: return "" + value;
 		}
 	}


### PR DESCRIPTION
With this PR, [BigInt](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/BigInt)s are now considered builtins and will have `n` appended to the number in the node field. Also, symbols can be displayed (using `String(symbol)`) instead of resulting in `TypeError: Cannot convert a Symbol value to a string` (symbols cannot be converted to strings using `"" + symbol`).